### PR TITLE
refact : localhost:3000 CORS 허용

### DIFF
--- a/src/main/java/com/efubtoy/team1/global/config/SecurityConfig.java
+++ b/src/main/java/com/efubtoy/team1/global/config/SecurityConfig.java
@@ -66,7 +66,8 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource=new UrlBasedCorsConfigurationSource();
         CorsConfiguration corsConfiguration=new CorsConfiguration();
 
-        corsConfiguration.addAllowedOrigin("*");
+        corsConfiguration.addAllowedOrigin("http://localhost:3000");
+        corsConfiguration.addAllowedOrigin("https://localhost:3000");
         corsConfiguration.addAllowedMethod("*");
         corsConfiguration.addAllowedHeader("*");
 


### PR DESCRIPTION
allow cors origin 설정을 와일드카드로 허용하여 에러가 발생하였습니다.
http://localhost:3000, https://localhost:3000 도메인으로 재설정하였습니다. 